### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,3 +151,13 @@ Use these keywords in PR title/body:
 - Full GitHub URLs to issues
 
 Multiple PRs can reference the same issue; status reflects the most recent PR action.
+
+## Cursor Cloud specific instructions
+
+- This is a static React/Vite/TypeScript portfolio site with no backend or database dependencies. All external services (Pageclip, Turnstile, GTM) degrade gracefully without API keys.
+- **Dev server**: `npm run dev` starts Vite on port 5173 with hot reload. No additional services need to be started.
+- **Lint**: `npm run lint` — as of the current commit, ESLint 10.3.0 has a pre-existing `ConfigError` related to plugin format in `eslint.config.js`. This is not caused by the cloud environment.
+- **Build**: `npm run build` runs `tsc -b && vite build` and outputs to `dist/`. A large-chunk warning for `visualizeme.html` is expected and non-blocking.
+- **E2E tests**: `npm run test:e2e` uses Playwright. Run `npx playwright install --with-deps chromium` first to download browser binaries. The Playwright config auto-starts a preview server on port 4173.
+- **No `npm test` script** exists — unit tests are not yet wired up. Only Playwright e2e tests are available.
+- **Environment variables** are all optional with safe defaults; see the "Environment Variables" section above. The app renders fully without any `.env.local` file.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with environment-specific notes for future cloud agents, including:

- Dev server, lint, build, and e2e test commands with known caveats
- Pre-existing ESLint config error note (not introduced by this PR)
- Playwright browser binary installation reminder
- Confirmation that no env vars or external services are required for local dev

## Verification

The dev environment was fully set up and tested:

- `npm install` — dependencies installed successfully
- `npm run build` — TypeScript compilation and Vite build succeeded
- `npm run dev` — Vite dev server started on port 5173, serving the portfolio correctly
- Contact form, theme toggle, and all page sections verified working via browser

### Demo

[portfolio_demo_walkthrough.mp4](https://cursor.com/agents/bc-2f643b43-d574-4d19-84e7-55f2d3c7a338/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fportfolio_demo_walkthrough.mp4)

[Hero section in light mode](https://cursor.com/agents/bc-2f643b43-d574-4d19-84e7-55f2d3c7a338/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhero_light_mode.webp)
[Contact form filled with test data](https://cursor.com/agents/bc-2f643b43-d574-4d19-84e7-55f2d3c7a338/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcontact_form_filled.webp)
[Dark mode after theme toggle](https://cursor.com/agents/bc-2f643b43-d574-4d19-84e7-55f2d3c7a338/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdark_mode_toggle.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2f643b43-d574-4d19-84e7-55f2d3c7a338"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f643b43-d574-4d19-84e7-55f2d3c7a338"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

